### PR TITLE
Fix BooleanConversionFilter bug when nil value at top level

### DIFF
--- a/lib/chamber/filters/boolean_conversion_filter.rb
+++ b/lib/chamber/filters/boolean_conversion_filter.rb
@@ -19,8 +19,6 @@ class   BooleanConversionFilter
       if value.respond_to? :each_pair
         execute(value)
       else
-        break if value.nil?
-
         settings[key] = if value.is_a? String
                           case value
                           when 'false', 'f', 'no'

--- a/spec/lib/chamber/filters/boolean_conversion_filter_spec.rb
+++ b/spec/lib/chamber/filters/boolean_conversion_filter_spec.rb
@@ -21,6 +21,7 @@ describe  BooleanConversionFilter do
                                                   non_boolean:        Time.utc(2012, 8, 1),
                                                   nilly:              nil, },
                                                 false_boolean:        'false',
+                                                nilly:                nil,
                                                 non_boolean:          [1, 2, 3] })
 
     expect(filtered_data).to eql( true_boolean:       true,
@@ -37,6 +38,7 @@ describe  BooleanConversionFilter do
                                     non_boolean:        Time.utc(2012, 8, 1),
                                     nilly:              nil, },
                                   false_boolean:        false,
+                                  nilly:                nil,
                                   non_boolean:          [1, 2, 3] )
   end
 end


### PR DESCRIPTION
This fixes an issue where if the top-level config hash contains a `nil`, we would break out of `each_pair`, causing the entire `execute` method to return `nil` (and therefore making Chamber return `nil` for `Chamber.env.data`).

This might not be the best fix -- I'm not sure what the intention of the original code was. Depending on the answer to that question, `next if value.nil?` might be more appropriate.
