### PR TITLE
Ensure Chamber loads Chamber::Instance in bin/chamber

### DIFF
--- a/bin/chamber
+++ b/bin/chamber
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'chamber'
 require 'chamber/binary/runner'
 
 Chamber::Binary::Runner.start


### PR DESCRIPTION
Fixes #29.

The problem is that https://github.com/thekompanee/chamber/blob/master/lib/chamber/commands/initialize.rb#L13 calls `Chamber.configuration` which is part of the `Chamber::Instance` class that the `Chamber` singleton delegates to via method_missing. Since the `bin/chamber` file only includes `chamber/binary/runner`, the `Chamber` singleton is never correctly initiated.
