### PR TITLE
Disable logging in Hashie::Mash subclasses while upgrading to version 3.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     chamber (2.10.1)
-      hashie (~> 3.4, < 3.5)
+      hashie (~> 3.5.2)
       thor (~> 0.19.1)
 
 GEM
@@ -20,7 +20,7 @@ GEM
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
-    hashie (3.4.6)
+    hashie (3.5.5)
     i18n (0.8.0)
     minitest (5.10.1)
     rspec (3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     chamber (2.10.1)
-      hashie (~> 3.3)
+      hashie (~> 3.4, < 3.5)
       thor (~> 0.19.1)
 
 GEM
@@ -20,7 +20,7 @@ GEM
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
-    hashie (3.3.1)
+    hashie (3.4.6)
     i18n (0.8.0)
     minitest (5.10.1)
     rspec (3.4.0)
@@ -40,7 +40,7 @@ GEM
       fuubar (~> 2.0)
       rspec (~> 3.1)
     ruby-progressbar (1.8.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)

--- a/chamber.gemspec
+++ b/chamber.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['{test,spec,features}/**/*']
 
   spec.add_dependency             'thor', ["~> 0.19.1"]
-  spec.add_dependency             'hashie', ["~> 3.3"]
+  spec.add_dependency             'hashie', ["~> 3.4", "< 3.5"]
 
   spec.add_development_dependency 'rspec', ["~> 3.0"]
   spec.add_development_dependency 'rspectacular', ["~> 0.46"]

--- a/chamber.gemspec
+++ b/chamber.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['{test,spec,features}/**/*']
 
   spec.add_dependency             'thor', ["~> 0.19.1"]
-  spec.add_dependency             'hashie', ["~> 3.4", "< 3.5"]
+  spec.add_dependency             'hashie', ["~> 3.5.2"]
 
   spec.add_development_dependency 'rspec', ["~> 3.0"]
   spec.add_development_dependency 'rspectacular', ["~> 0.46"]

--- a/lib/chamber/context_resolver.rb
+++ b/lib/chamber/context_resolver.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 require 'pathname'
 require 'socket'
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 require 'chamber/decryption_key'
 
 module  Chamber
 class   ContextResolver
   def initialize(options = {})
-    self.options = Hashie::Mash.new(options)
+    self.options = HashieMash.new(options)
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity

--- a/lib/chamber/environmentable.rb
+++ b/lib/chamber/environmentable.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 
 module  Chamber
 module  Environmentable
   SECURE_KEY_TOKEN = /\A_secure_/
 
   def with_environment(settings, parent_keys, hash_block, value_block)
-    environment_hash = Hashie::Mash.new
+    environment_hash = HashieMash.new
 
     settings.each_pair do |key, value|
       environment_key  = key.to_s.gsub(SECURE_KEY_TOKEN, '')

--- a/lib/chamber/filters/decryption_filter.rb
+++ b/lib/chamber/filters/decryption_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'openssl'
 require 'base64'
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 require 'yaml'
 require 'chamber/encryption_methods/public_key'
 require 'chamber/encryption_methods/ssl'
@@ -30,7 +30,7 @@ class   DecryptionFilter
   attr_reader   :decryption_key
 
   def execute(raw_data = data)
-    settings = Hashie::Mash.new
+    settings = HashieMash.new
 
     raw_data.each_pair do |key, value|
       settings[key] = if value.respond_to? :each_pair

--- a/lib/chamber/filters/encryption_filter.rb
+++ b/lib/chamber/filters/encryption_filter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'openssl'
 require 'base64'
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 require 'yaml'
 require 'chamber/encryption_methods/public_key'
 require 'chamber/encryption_methods/ssl'
@@ -29,7 +29,7 @@ class     EncryptionFilter
   attr_reader   :encryption_key
 
   def execute(raw_data = data)
-    settings = Hashie::Mash.new
+    settings = HashieMash.new
 
     raw_data.each_pair do |key, value|
       settings[key] = if value.respond_to? :each_pair

--- a/lib/chamber/filters/insecure_filter.rb
+++ b/lib/chamber/filters/insecure_filter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 require 'chamber/filters/secure_filter'
 
 module  Chamber
@@ -12,7 +12,7 @@ class   InsecureFilter < SecureFilter
 
   def execute(raw_data = data)
     securable_settings = super
-    settings           = Hashie::Mash.new
+    settings           = HashieMash.new
 
     securable_settings.each_pair do |key, value|
       value = if value.respond_to? :each_pair

--- a/lib/chamber/filters/namespace_filter.rb
+++ b/lib/chamber/filters/namespace_filter.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 
 module  Chamber
 module  Filters
 class   NamespaceFilter
   def initialize(options = {})
-    self.data       = Hashie::Mash.new(options.fetch(:data))
+    self.data       = HashieMash.new(options.fetch(:data))
     self.namespaces = options.fetch(:namespaces)
   end
 
@@ -20,11 +20,11 @@ class   NamespaceFilter
 
   def execute
     if data_is_namespaced?
-      namespaces.each_with_object(Hashie::Mash.new) do |namespace, filtered_data|
+      namespaces.each_with_object(HashieMash.new) do |namespace, filtered_data|
         filtered_data.merge!(data[namespace]) if data[namespace]
       end
     else
-      Hashie::Mash.new(data)
+      HashieMash.new(data)
     end
   end
 

--- a/lib/chamber/filters/secure_filter.rb
+++ b/lib/chamber/filters/secure_filter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 
 module  Chamber
 module  Filters
@@ -7,7 +7,7 @@ class   SecureFilter
   SECURE_KEY_TOKEN = /\A_secure_/
 
   def initialize(options = {})
-    self.data = Hashie::Mash.new(options.fetch(:data))
+    self.data = HashieMash.new(options.fetch(:data))
   end
 
   def self.execute(options = {})
@@ -19,7 +19,7 @@ class   SecureFilter
   attr_accessor :data
 
   def execute(raw_data = data)
-    settings = Hashie::Mash.new
+    settings = HashieMash.new
 
     raw_data.each_pair do |key, value|
       secure_value  = if value.respond_to? :each_pair

--- a/lib/chamber/filters/translate_secure_keys_filter.rb
+++ b/lib/chamber/filters/translate_secure_keys_filter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 
 module  Chamber
 module  Filters
@@ -19,7 +19,7 @@ class   TranslateSecureKeysFilter
   attr_accessor :data
 
   def execute(raw_data = data)
-    settings = Hashie::Mash.new
+    settings = HashieMash.new
 
     raw_data.each_pair do |key, value|
       value = execute(value) if value.respond_to? :each_pair

--- a/lib/chamber/hashie_mash.rb
+++ b/lib/chamber/hashie_mash.rb
@@ -1,0 +1,5 @@
+require 'hashie/mash'
+
+class HashieMash < Hashie::Mash
+  disable_warnings
+end

--- a/lib/chamber/settings.rb
+++ b/lib/chamber/settings.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'hashie/mash'
+require 'chamber/hashie_mash'
 require 'chamber/namespace_set'
 require 'chamber/filters/namespace_filter'
 require 'chamber/filters/encryption_filter'
@@ -244,7 +244,7 @@ class   Settings
                 :raw_data
 
   def raw_data=(new_raw_data)
-    @raw_data   = Hashie::Mash.new(new_raw_data)
+    @raw_data   = HashieMash.new(new_raw_data)
   end
 
   def namespaces=(raw_namespaces)

--- a/spec/lib/chamber/settings_spec.rb
+++ b/spec/lib/chamber/settings_spec.rb
@@ -162,7 +162,7 @@ HEREDOC
 
     expect(settings.to_hash).to     eql('setting' => 'value')
     expect(settings.to_hash).to     be_a Hash
-    expect(settings.to_hash).not_to be_a Hashie::Mash
+    expect(settings.to_hash).not_to be_a HashieMash
   end
 
   it 'can convert itself into a hash with flattened names' do
@@ -186,7 +186,7 @@ HEREDOC
       %w{there}                        => 'was not that easy?',
     )
     expect(settings.to_flattened_name_hash).to     be_a Hash
-    expect(settings.to_flattened_name_hash).not_to be_a Hashie::Mash
+    expect(settings.to_flattened_name_hash).not_to be_a HashieMash
   end
 
   it 'does not allow manipulation of the internal setting hash when converted to ' \


### PR DESCRIPTION
Fixes https://github.com/thekompanee/chamber/issues/49 by disabling logging via Mash subclasses to silence Hashie Warnings

https://github.com/intridea/hashie/blob/master/UPGRADING.md#upgrading-to-352

Why:

* Since the update to Hashie 3.5 the following warning is written to STDOUT when booting our Rails application:

```[bash]
❯ chamber secure
W, [2017-03-07T12:12:47.983000 #17933]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#default defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
...
W, [2017-03-07T12:12:55.025000 #17933]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#default defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
     encrypt  DEFAULT_MIXPANEL_MIXPANEL_TOKEN
     encrypt  DEMO_MIXPANEL_MIXPANEL_TOKEN
     encrypt  DEVELOPMENT_MIXPANEL_MIXPANEL_TOKEN
     encrypt  PRODUCTION_MIXPANEL_MIXPANEL_TOKEN
     encrypt  STAGING_MIXPANEL_MIXPANEL_TOKEN
     encrypt  TEST_MIXPANEL_MIXPANEL_TOKEN
W, [2017-03-07T12:12:55.068000 #17933]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#default defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
...
W, [2017-03-07T12:12:57.449000 #17933]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#default defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
❯ 
```
Read more at: intridea/hashie#394