### PR TITLE
Maintain type when setting by environment variable

### DIFF
--- a/lib/chamber/filters/environment_filter.rb
+++ b/lib/chamber/filters/environment_filter.rb
@@ -19,21 +19,33 @@ class   EnvironmentFilter
   #
   #   ###
   #   # Injects the current environment variables
+  #   # Replaces arrays
+  #   # Maintains type of integers and arrays
   #   #
   #   ENV['LEVEL_ONE_1_LEVEL_TWO_1']               = 'env value 1'
   #   ENV['LEVEL_ONE_1_LEVEL_TWO_2_LEVEL_THREE_1'] = 'env value 2'
+  #   ENV['LEVEL_ONE_1_INTEGER']                   = '2'
+  #   ENV['LEVEL_ONE_1_FLOAT']                     = '3.14'
+  #   ENV['LEVEL_ONE_1_ARRAY_0']                   = 'env value 3'
+  #   ENV['LEVEL_ONE_1_ARRAY_1']                   = 'env value 4'
   #
   #   EnvironmentFilter.execute(
   #     level_one_1: {
   #       level_two_1: 'value 1',
   #       level_two_2: {
-  #         level_three_1: 'value 2' } } )
+  #         level_three_1: 'value 2' },
+  #       integer: 1,
+  #       float: 2.17,
+  #       array: [ 'value 3', 'value 4' ] } )
   #
   #   # => {
   #     'level_one_1' => {
   #       'level_two_1' => 'env value 1',
   #       'level_two_2' => {
   #         'level_three_1' => 'env value 2',
+  #       'integer' => 2,
+  #       'float' => 3.14,
+  #       'array' => [ 'env value 3', 'env value 4' ]
   #   }
   #
   #   ###

--- a/lib/chamber/filters/environment_filter.rb
+++ b/lib/chamber/filters/environment_filter.rb
@@ -68,7 +68,11 @@ class   EnvironmentFilter
                        { key => execute(value, environment_keys) }
                      end,
                      lambda do |key, value, environment_key|
-                       { key => (ENV[environment_key] || value) }
+                       if value.is_a? Integer
+                         { key => ENV[environment_key].nil? ? value : ENV[environment_key].to_i }
+                       else
+                         { key => (ENV[environment_key] || value) }
+                       end
                      end)
   end
 end

--- a/lib/chamber/filters/environment_filter.rb
+++ b/lib/chamber/filters/environment_filter.rb
@@ -68,14 +68,36 @@ class   EnvironmentFilter
                        { key => execute(value, environment_keys) }
                      end,
                      lambda do |key, value, environment_key|
-                       if value.is_a? Integer
-                         { key => ENV[environment_key].nil? ? value : ENV[environment_key].to_i }
-                       elsif value.is_a? Float
-                         { key => ENV[environment_key].nil? ? value : ENV[environment_key].to_f }
+                       if value.is_a? Array
+                         if ENV[environment_key] == '0'
+                           { key => [] }
+                         else
+                           env_values = ENV.keys
+                                        .select{ |e|
+                                          e =~ /^#{environment_key}_\d+$/
+                                        }.sort.map{ |e|
+                                          match_type(ENV[e], value[0])
+                                        }
+                           if env_values.length > 0
+                             { key => env_values }
+                           else
+                             { key => value }
+                           end
+                         end
                        else
-                         { key => (ENV[environment_key] || value) }
+                         { key => ENV[environment_key].nil? ? value : match_type(ENV[environment_key], value) }
                        end
                      end)
+  end
+
+  def match_type(value, template)
+    if template.is_a? Integer
+      value.to_i
+    elsif template.is_a? Float
+      value.to_f
+    else
+      value
+    end
   end
 end
 end

--- a/lib/chamber/filters/environment_filter.rb
+++ b/lib/chamber/filters/environment_filter.rb
@@ -70,6 +70,8 @@ class   EnvironmentFilter
                      lambda do |key, value, environment_key|
                        if value.is_a? Integer
                          { key => ENV[environment_key].nil? ? value : ENV[environment_key].to_i }
+                       elsif value.is_a? Float
+                         { key => ENV[environment_key].nil? ? value : ENV[environment_key].to_f }
                        else
                          { key => (ENV[environment_key] || value) }
                        end

--- a/spec/lib/chamber/filters/environment_filter_spec.rb
+++ b/spec/lib/chamber/filters/environment_filter_spec.rb
@@ -43,6 +43,26 @@ describe  EnvironmentFilter do
 
     ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
   end
+
+  it 'can extract an integer from the environment if an existing variable' \
+     'matches the composite key' do
+
+    ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2'
+
+    filtered_data = EnvironmentFilter.execute(data: {
+                                                test_setting_group: {
+                                                  test_setting_level: {
+                                                    test_setting: 1,
+                                                  },
+                                                },
+                                              })
+
+    test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
+
+    expect(test_setting).to eql 2
+
+    ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+  end
 end
 end
 end

--- a/spec/lib/chamber/filters/environment_filter_spec.rb
+++ b/spec/lib/chamber/filters/environment_filter_spec.rb
@@ -70,6 +70,33 @@ describe  EnvironmentFilter do
       ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1')
     end
 
+    it 'can replace an array in numerical order' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0'] = 'value 4'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_2'] = 'value 6'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1'] = 'value 5'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [
+                                                        'value 1',
+                                                        'value 2',
+                                                        'value 3'
+                                                      ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ 'value 4', 'value 5', 'value 6' ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_2')
+
+    end
+
     it 'can replace an array with an empty array' do
       ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY'] = '0'
 
@@ -88,6 +115,24 @@ describe  EnvironmentFilter do
       test_array  = filtered_data.test_setting_group.test_setting_level.test_array
 
       expect(test_array).to eql [ ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY')
+    end
+
+    it 'defaults to strings in an empty array' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0'] = '123'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: []
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array[0]).to be_a String
 
       ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY')
     end

--- a/spec/lib/chamber/filters/environment_filter_spec.rb
+++ b/spec/lib/chamber/filters/environment_filter_spec.rb
@@ -5,63 +5,129 @@ require 'chamber/filters/environment_filter'
 module    Chamber
 module    Filters
 describe  EnvironmentFilter do
-  it 'can extract data from the environment if an existing variable matches the ' \
-     'composite key' do
+  context 'string variables' do
+    it 'can extract data from the environment if an existing variable matches the ' \
+       'composite key' do
 
-    ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = 'value 2'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = 'value 2'
 
-    filtered_data = EnvironmentFilter.execute(data: {
-                                                test_setting_group: {
-                                                  test_setting_level: {
-                                                    test_setting: 'value 1',
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting: 'value 1',
+                                                    },
                                                   },
-                                                },
-                                              })
+                                                })
 
-    test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
+      test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
 
-    expect(test_setting).to eql 'value 2'
+      expect(test_setting).to eql 'value 2'
 
-    ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
+
+    it 'does not affect items which are not stored in the environment' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = 'value 2'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting:    'value 1',
+                                                      another_setting: 'value 3',
+                                                    },
+                                                  },
+                                                })
+
+      another_setting = filtered_data.test_setting_group.test_setting_level.another_setting
+
+      expect(another_setting).to eql 'value 3'
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
   end
 
-  it 'does not affect items which are not stored in the environment' do
-    ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = 'value 2'
+  context 'integer variables' do
+    it 'can extract an integer from the environment if an existing variable' \
+       'matches the composite key' do
 
-    filtered_data = EnvironmentFilter.execute(data: {
-                                                test_setting_group: {
-                                                  test_setting_level: {
-                                                    test_setting:    'value 1',
-                                                    another_setting: 'value 3',
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting: 1,
+                                                    },
                                                   },
-                                                },
-                                              })
+                                                })
 
-    another_setting = filtered_data.test_setting_group.test_setting_level.another_setting
+      test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
 
-    expect(another_setting).to eql 'value 3'
+      expect(test_setting).to eql 2
 
-    ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
+
+    it 'does not affect integers that are not stored in the environment' do
+
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting: 1,
+                                                      another_setting: 3
+                                                    },
+                                                  },
+                                                })
+
+      another_setting  = filtered_data.test_setting_group.test_setting_level.another_setting
+
+      expect(another_setting).to eql 3
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
   end
 
-  it 'can extract an integer from the environment if an existing variable' \
-     'matches the composite key' do
+  context 'float variables' do
+    it 'can extract a float from the environment if an existing variable' \
+       'matches the composite key' do
 
-    ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2.3'
 
-    filtered_data = EnvironmentFilter.execute(data: {
-                                                test_setting_group: {
-                                                  test_setting_level: {
-                                                    test_setting: 1,
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting: 1.2,
+                                                    },
                                                   },
-                                                },
-                                              })
+                                                })
 
-    test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
+      test_setting  = filtered_data.test_setting_group.test_setting_level.test_setting
 
-    expect(test_setting).to eql 2
+      expect(test_setting).to eql 2.3
 
-    ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
+
+    it 'does not affect integers that are not stored in the environment' do
+
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING'] = '2.3'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_setting: 1.2,
+                                                      another_setting: 3.4
+                                                    },
+                                                  },
+                                                })
+
+      another_setting  = filtered_data.test_setting_group.test_setting_level.another_setting
+
+      expect(another_setting).to eql 3.4
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
   end
 end
 end

--- a/spec/lib/chamber/filters/environment_filter_spec.rb
+++ b/spec/lib/chamber/filters/environment_filter_spec.rb
@@ -44,6 +44,53 @@ describe  EnvironmentFilter do
 
       ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
     end
+
+    it 'can extract an array from the environment if an existing set of' \
+       'variables match the composite key' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0'] = 'value 4'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1'] = 'value 5'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [
+                                                        'value 1',
+                                                        'value 2',
+                                                        'value 3'
+                                                      ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ 'value 4', 'value 5' ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1')
+    end
+
+    it 'can replace an array with an empty array' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY'] = '0'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [
+                                                        'value 1',
+                                                        'value 2',
+                                                        'value 3'
+                                                      ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY')
+    end
   end
 
   context 'integer variables' do
@@ -86,6 +133,45 @@ describe  EnvironmentFilter do
 
       ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
     end
+
+    it 'can extract an array from the environment if an existing set of' \
+       'variables match the composite key' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0'] = '4'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1'] = '5'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [ 1, 2, 3 ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ 4, 5 ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1')
+    end
+
+    it 'can replace an array with an empty array' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY'] = '0'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [ 1, 2, 3 ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY')
+    end
   end
 
   context 'float variables' do
@@ -127,6 +213,45 @@ describe  EnvironmentFilter do
       expect(another_setting).to eql 3.4
 
       ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_SETTING')
+    end
+
+    it 'can extract an array from the environment if an existing set of' \
+       'variables match the composite key' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0'] = '4.2'
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1'] = '5.3'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [ 1.9, 2.8, 3.7 ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ 4.2, 5.3 ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_0')
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY_1')
+    end
+
+    it 'can replace an array with an empty array' do
+      ENV['TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY'] = '0'
+
+      filtered_data = EnvironmentFilter.execute(data: {
+                                                  test_setting_group: {
+                                                    test_setting_level: {
+                                                      test_array: [ 1.9, 2.8, 3.7 ]
+                                                    },
+                                                  },
+                                                })
+
+      test_array  = filtered_data.test_setting_group.test_setting_level.test_array
+
+      expect(test_array).to eql [ ]
+
+      ENV.delete('TEST_SETTING_GROUP_TEST_SETTING_LEVEL_TEST_ARRAY')
     end
   end
 end

--- a/spec/lib/chamber_spec.rb
+++ b/spec/lib/chamber_spec.rb
@@ -104,15 +104,19 @@ describe 'Chamber' do
 
   it 'prefers values stored in environment variables over those in the YAML files' do
     ENV['TEST_MY_SETTING'] = 'some_other_value'
-    ENV['TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY'] = 'something'
+    ENV['TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_0'] = 'something 0'
+    ENV['TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_1'] = 'something 1'
+    ENV['TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_2'] = 'something 2'
 
     Chamber.load(basepath: '/tmp/chamber')
     expect(Chamber.test.my_setting).to eql 'some_other_value'
-    expect(Chamber.test.another_level.level_three.an_array).to eql 'something'
+    expect(Chamber.test.another_level.level_three.an_array).to eql [ 'something 0', 'something 1', 'something 2' ]
     expect(Chamber.test.my_dynamic_setting).to eql 2
 
     ENV.delete 'TEST_MY_SETTING'
-    ENV.delete 'TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY'
+    ENV.delete 'TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_0'
+    ENV.delete 'TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_1'
+    ENV.delete 'TEST_ANOTHER_LEVEL_LEVEL_THREE_AN_ARRAY_2'
   end
 
   it 'can load files based on the namespace passed in' do


### PR DESCRIPTION
When a setting is an integer or a float in the settings file then when it is replaced by an environment variable it will convert it to an integer or float rather than set it as a string

Arrays defined in the settings file as:

```
array1: [ one, two, three ]
array2:
  - four
  - five
  - six
```

can be replaced with environment variables as:

```
ARRAY1_0=first
ARRAY1_1=second
ARRAY2_0=third
ARRAY2_1=four
```

This will completely replace the array from the configuration file it it will be ordered by the number after the underscore, ignoring missing numbers. An empty array can be set with

```
ARRAY1=0
```

The types of the elements of the array will all be the same and this type will be taken to match the first element from the settings file or a string if it is empty.

I have had to modify one of the tests in `spec/lib/chamber_spec.rb`.