### PR TITLE
Update version of the thor gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     chamber (2.10.2)
       hashie (~> 3.3)
-      thor (~> 0.19.1)
+      thor (~> 0.20.0)
 
 GEM
   remote: https://rubygems.org/
@@ -49,7 +49,7 @@ GEM
       fuubar (~> 2.0)
       rspec (~> 3.1)
     ruby-progressbar (1.9.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     chamber (2.10.2)
       hashie (~> 3.3)
-      thor (~> 0.20.0)
+      thor (>= 0.19.1, < 0.21)
 
 GEM
   remote: https://rubygems.org/

--- a/chamber.gemspec
+++ b/chamber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  spec.add_dependency             'thor', ["~> 0.19.1"]
+  spec.add_dependency             'thor', ["~> 0.20.0"]
   spec.add_dependency             'hashie', ["~> 3.3"]
 
   spec.add_development_dependency 'rspec', ["~> 3.5"]

--- a/chamber.gemspec
+++ b/chamber.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 
-  spec.add_dependency             'thor', ["~> 0.20.0"]
+  spec.add_dependency             'thor', [">= 0.19.1", "< 0.21"]
   spec.add_dependency             'hashie', ["~> 3.3"]
 
   spec.add_development_dependency 'rspec', ["~> 3.5"]


### PR DESCRIPTION
## Why This Change Is Necessary

- [ ] Bug Fix
- [x] New Feature

This isn't really a major issue but I notice that the [Thor gem](https://rubygems.org/gems/thor/) gem has had a new minor release relatively recently (0.20) and Chamber is pinned to version 0.19. The [change log](https://github.com/erikhuda/thor/blob/master/CHANGELOG.md) lists three changes that are all added features so it should not have any effect but there may be conflicts if other gems used alongside Chamber require the later version.

## How These Changes Address the Issue
<!--- Describe, at a high level, what was done to affect change. -->
<!--- If your change is obvious, you may be able to omit addressing this. -->
I have made the gemfile less restrictive to allow any version of thor greater than or including 0.19.1 and strictly less than 0.21.

## Side Effects Caused By This Change

- [ ] This Causes a Breaking Change

No side effects to my knowledge.

## Checklist:
- [x] I have run `rubocop` against the codebase (Maybe it would be helpful to add `rubocop-rspec` as a development dependency)
- [ ] I have added tests to cover my changes (N/A)
- [x] All new and existing tests passed