### PR TITLE
Allow hostnames to have dot and dash

### DIFF
--- a/lib/chamber/keys/decryption.rb
+++ b/lib/chamber/keys/decryption.rb
@@ -10,7 +10,7 @@ class   Decryption < Chamber::Keys::Base
                         \A          # Beginning of Filename
                         \.chamber   # Initial Chamber Prefix
                         \.          # Pre-Namespace Dot
-                        (\w+)       # Namespace
+                        ([\w\-\.]+) # Namespace
                         \.pem       # Extension
                         \z          # End of Filename
                       /x

--- a/lib/chamber/keys/encryption.rb
+++ b/lib/chamber/keys/encryption.rb
@@ -10,7 +10,7 @@ class   Encryption < Chamber::Keys::Base
                         \A          # Beginning of Filename
                         \.chamber   # Initial Chamber Prefix
                         \.          # Pre-Namespace Dot
-                        (\w+)       # Namespace
+                        ([\w\-\.]+) # Namespace
                         \.pub\.pem  # Extension
                         \z          # End of Filename
                       /x

--- a/spec/fixtures/keys/.chamber.example-host.com.enc
+++ b/spec/fixtures/keys/.chamber.example-host.com.enc
@@ -1,0 +1,1 @@
+example-host.com encrypted private key

--- a/spec/fixtures/keys/.chamber.example-host.com.pem
+++ b/spec/fixtures/keys/.chamber.example-host.com.pem
@@ -1,0 +1,1 @@
+example-host.com private key

--- a/spec/fixtures/keys/.chamber.example-host.com.pub.pem
+++ b/spec/fixtures/keys/.chamber.example-host.com.pub.pem
@@ -1,0 +1,1 @@
+example-host.com public key

--- a/spec/lib/chamber/keys/decryption_spec.rb
+++ b/spec/lib/chamber/keys/decryption_spec.rb
@@ -133,10 +133,12 @@ describe  Decryption do
                           'spec/fixtures/keys/.chamber.pem',
                           'spec/fixtures/keys/.chamber.production.pem',
                           'spec/fixtures/keys/.chamber.test.pem',
+                          'spec/fixtures/keys/.chamber.example-host.com.pem',
                         ],
           )
 
     expect(key).to eql(
+                        :"example-host.com" => "example-host.com private key\n",
                         __default:   "default private key\n",
                         development: "development private key\n",
                         production:  "production private key\n",

--- a/spec/lib/chamber/keys/encryption_spec.rb
+++ b/spec/lib/chamber/keys/encryption_spec.rb
@@ -121,10 +121,12 @@ describe  Encryption do
                           'spec/fixtures/keys/.chamber.pub.pem',
                           'spec/fixtures/keys/.chamber.production.pub.pem',
                           'spec/fixtures/keys/.chamber.test.pub.pem',
+                          'spec/fixtures/keys/.chamber.example-host.com.pub.pem',
                         ],
           )
 
     expect(key).to eql(
+                        :"example-host.com" => "example-host.com public key\n",
                         __default:   "default public key\n",
                         development: "development public key\n",
                         production:  "production public key\n",


### PR DESCRIPTION
<!--- Well formatted issues help everyone.  Take a few minutes to get a -->
<!--- primer on markdown here: http://bit.ly/2lB1raW -->

## Why This Change Is Necessary

Previously keys that were namespaced with hostnames with dashes or
dots in their names were ignored and merged into __default namespace.

<!--- Identify the High Level Type of Change -->
- [ ] Bug Fix

<!--- Now describe to reviewers of your pull request what to expect in the -->
<!--- PR, thereby allowing them to more easily identify and point out -->
<!--- unrelated changes. -->

It allows to use keys with hostanames with dots or dashes.