### PR TITLE
Support .gitignores that are not at the repository root

### DIFF
--- a/lib/chamber/commands/securable.rb
+++ b/lib/chamber/commands/securable.rb
@@ -53,7 +53,7 @@ module  Securable
     end
 
     `
-      git ls-files --other --ignored --exclude-from=.gitignore |
+      git ls-files --other --ignored --exclude-per-directory=.gitignore |
       sed -e "s|^|#{Shellwords.escape(rootpath.to_s)}/|" |
       grep --colour=never -E '#{shell_escaped_chamber_filenames.join('|')}'
     `.split("\n")


### PR DESCRIPTION
The path that `git ls-files --exclude-from` takes is considered to be relative to the repository root, but if your chamber root is in a deeper subdirectory (not at the repo root), calling `chamber secure` fails:

```
❯ chamber secure
fatal: cannot use .gitignore as an exclude file
```

because the `.gitignore` it's looking for isn't at the repo root. This commit changes it to use `--exclude-per-directory`, which will search for .gitignores recursively and follow *all* of them, which is more than likely the desired behavior here.

Another option would be to replace the `--exclude-from` with `--exclude-standard`, which doesn't take an argument and just follows .gitignores and .git/info/exclude and such automatically.