### PR TITLE
Unsecure

### DIFF
--- a/lib/chamber/binary/runner.rb
+++ b/lib/chamber/binary/runner.rb
@@ -9,6 +9,7 @@ require 'chamber/binary/circle_ci'
 require 'chamber/commands/show'
 require 'chamber/commands/files'
 require 'chamber/commands/secure'
+require 'chamber/commands/unsecure'
 require 'chamber/commands/sign'
 require 'chamber/commands/verify'
 require 'chamber/commands/compare'
@@ -152,6 +153,21 @@ class   Runner < Thor
 
   def secure
     Commands::Secure.call(**options.transform_keys(&:to_sym).merge(shell: self))
+  end
+
+  ################################################################################
+
+  desc 'unsecure',
+       'Decrypts all encrypted values using the current key(s)' \
+
+  method_option :dry_run,
+                type:    :boolean,
+                aliases: '-d',
+                desc:    'Does not actually decrypt anything, but instead displays ' \
+                         'what values would be decrypted'
+
+  def unsecure
+    Commands::Unsecure.call(**options.transform_keys(&:to_sym).merge(shell: self))
   end
 
   ################################################################################

--- a/lib/chamber/commands/unsecure.rb
+++ b/lib/chamber/commands/unsecure.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'chamber/commands/base'
+require 'chamber/commands/securable'
+
+module  Chamber
+module  Commands
+class   Unsecure < Chamber::Commands::Base
+  include Chamber::Commands::Securable
+
+  def initialize(**args)
+    super(**args.merge(namespaces: ['*']))
+  end
+
+  def call
+    disable_warnings do
+      current_settings.decrypt.to_environment.each_key do |key|
+        color = dry_run ? :blue : :green
+
+        shell.say_status 'decrypt', key, color
+      end
+    end
+
+  end
+
+  private
+
+  def disable_warnings
+    $stderr = ::File.open('/dev/null', 'w')
+
+    yield
+
+    $stderr = STDERR
+  end
+end
+end
+end

--- a/lib/chamber/commands/unsecure.rb
+++ b/lib/chamber/commands/unsecure.rb
@@ -14,13 +14,14 @@ class   Unsecure < Chamber::Commands::Base
 
   def call
     disable_warnings do
-      current_settings.decrypt.to_environment.each_key do |key|
+      current_settings.secure.to_environment.each_key do |key|
         color = dry_run ? :blue : :green
 
         shell.say_status 'decrypt', key, color
       end
     end
 
+    chamber.unsecure unless dry_run
   end
 
   private

--- a/lib/chamber/file_set.rb
+++ b/lib/chamber/file_set.rb
@@ -192,6 +192,10 @@ class   FileSet
     files.each(&:secure)
   end
 
+  def unsecure
+    files.each(&:decrypt)
+  end
+
   def sign
     files.each(&:sign)
   end

--- a/lib/chamber/instance.rb
+++ b/lib/chamber/instance.rb
@@ -38,6 +38,10 @@ class   Instance
     files.secure
   end
 
+  def unsecure
+    files.unsecure
+  end
+
   def sign
     files.sign
   end

--- a/lib/chamber/settings.rb
+++ b/lib/chamber/settings.rb
@@ -267,6 +267,22 @@ class   Settings
                  ))
   end
 
+  def decrypted
+    Settings.new(**metadata.merge(
+                   settings:     raw_data,
+                   post_filters:  [Filters::DecryptionFilter]
+                 ))
+  end
+
+  def encrypted
+    Settings.new(**metadata.merge(
+                   settings:     raw_data,
+                   pre_filters:  [Filters::EncryptionFilter],
+                   post_filters:  []
+                 ))
+  end
+
+
   def insecure
     Settings.new(**metadata.merge(
                    settings:     raw_data,


### PR DESCRIPTION
Why This Change Is Necessary
--------------------------------------------------------------------------------

This implements an `unsecure` command to fix #77. It's currently at the hack 'n' slash stage of development and I haven't implemented any tests because the existing tests do not pass for me locally so what's the point. 

![giphy](https://user-images.githubusercontent.com/14988/174446251-832f4d0e-3f28-4d22-9448-b4e3e0abb44a.gif)

That said, it _does_ work on my own chamber secrets. I'm only posting here at this stage as an FYI for anyone that needs it or wants to work on it

* [] Bug Fix
* [x] New Feature

How These Changes Address the Issue
--------------------------------------------------------------------------------

- Added a new `unsecure` command to the runner so running `chamber unsecure` decrypts and saves all your settings files
- A new Instance#unsecure command
- FileSet#unsecure
- File#decrypt
- Settings#encrypted and Settings#decrypted to return the encrypted and decrypted values

I don't love the name "unsecure" but I wanted to distinguish from "decrypt" because Chamber does decrypting all the time when a Rails app boots and "unsecuring" is a much more drastic action which persists the unencrypted settings. That said, I switched to "decrypt" in the Settings and File classes for reasons I can't remember.

Side Effects Caused By This Change
--------------------------------------------------------------------------------

* [] This Causes a Breaking Change
* [x] This Does Not Cause Any Known Side Effects

Checklist
--------------------------------------------------------------------------------

* [] I have run `rubocop` against the codebase
* [] I have added tests to cover my changes
* [] All new and existing tests passed

