### PR TITLE
Remove: grep and sed system dependencies

### DIFF
--- a/lib/chamber/commands/securable.rb
+++ b/lib/chamber/commands/securable.rb
@@ -52,11 +52,10 @@ module  Securable
       Shellwords.escape(filename)
     end
 
-    `
-      git ls-files --other --ignored --exclude-per-directory=.gitignore |
-      sed -e "s|^|#{Shellwords.escape(rootpath.to_s)}/|" |
-      grep --colour=never -E '#{shell_escaped_chamber_filenames.join('|')}'
-    `.split("\n")
+    `git ls-files --other --ignored --exclude-per-directory=.gitignore`
+      .split("\n")
+      .map { |filename| "#{Shellwords.escape(rootpath.to_s)}/#{filename}"}
+      .select { |filename| shell_escaped_chamber_filenames.include?(filename) }
   end
 end
 end


### PR DESCRIPTION
---

name: Remove:Remove: grep and sed system dependencies
about: Use plain Ruby in place of `grep` and `sed`

---

<!--lint ignore first-heading-level-->

Why This Change Is Necessary
--------------------------------------------------------------------------------

<!-- Identify the High Level Type of Change -->

* [x] Bug Fix
* [ ] New Feature

See: https://github.com/thekompanee/chamber/issues/82

How These Changes Address the Issue
--------------------------------------------------------------------------------

Replaces `sed` and `grep` usage with plain Ruby.

Side Effects Caused By This Change
--------------------------------------------------------------------------------

* [ ] This Causes a Breaking Change
* [x] This Does Not Cause Any Known Side Effects

Checklist
--------------------------------------------------------------------------------

* [ ] I have run `rubocop` against the codebase
* [ ] I have added tests to cover my changes
* [ ] All new and existing tests passed
