### PR TITLE
Revert "Chore: Autofix (Safe) 'Lint/RedundantRequireStatement'"

### DIFF
--- a/lib/chamber/commands/show.rb
+++ b/lib/chamber/commands/show.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+# `require 'pp'` is required.
+# See https://github.com/thekompanee/chamber/issues/84
+# rubocop:disable Lint/RedundantRequireStatement
 require 'pp'
+# rubocop:enable Lint/RedundantRequireStatement
+
 require 'chamber/commands/base'
 
 module  Chamber

--- a/lib/chamber/commands/show.rb
+++ b/lib/chamber/commands/show.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pp'
 require 'chamber/commands/base'
 
 module  Chamber


### PR DESCRIPTION
require 'pp' is required.

This reverts commit fe82e96d78e9a6ce0910bcaf6beb67645d13ca76.

Fixes #84 
