### PR TITLE
Update dependencies to include base64

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,8 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
+          - "3.4"
           - "ruby-head"
 
     continue-on-error:            ${{ endsWith(matrix.ruby, 'head') }}

--- a/chamber.gemspec
+++ b/chamber.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7.5'
 
   spec.add_dependency             'thor',          [">= 0.20.3", "< 2.0"]
+  spec.add_dependency             'base64',        ["~> 0.3"] if RUBY_VERSION >= "3.4.0"
 
   spec.add_development_dependency 'rspec',         ["~> 3.5"]
   spec.add_development_dependency 'rspectacular',  ["~> 0.46"]


### PR DESCRIPTION
---

name:  Update dependencies
about: Some gems have been removed from core Ruby and so need to be included explicitly

Fixes #87 

---

<!--lint ignore first-heading-level-->

Why This Change Is Necessary
--------------------------------------------------------------------------------

* [X] Bug Fix
* [] New Feature

This gem fails can fail in newer versions of Ruby due to the absence of certain gems. Specifically;

* `base64`
* TBC

How These Changes Address the Issue
--------------------------------------------------------------------------------

This PR adds the dependencies to the `gemspec` file.

The list of Ruby versions has been updated to include the latest supported Ruby versions.

Side Effects Caused By This Change
--------------------------------------------------------------------------------

* [] This Causes a Breaking Change
* [X] This Does Not Cause Any Known Side Effects

Checklist
--------------------------------------------------------------------------------

* [] I have run `rubocop` against the codebase
* [] I have added tests to cover my changes
* [] All new and existing tests passed
